### PR TITLE
Undefined index swpmvc_controller and swpmvc_method

### DIFF
--- a/swpmvc.php
+++ b/swpmvc.php
@@ -109,9 +109,8 @@ class swpMVCCore
     public function is_swpmvc_request()
     {
         global $wp_query;
-        $c = $wp_query->query_vars['swpmvc_controller'];
-        $m = $wp_query->query_vars['swpmvc_method'];
-        return (isset($c) and isset($m));
+
+        return (array_key_exists('swpmvc_controller', $wp_query->query_vars) and array_key_exists('swpmvc_method', $wp_query->query_vars));
     }
     
     public function enqueue_jswpmvc()


### PR DESCRIPTION
I was getting these 2 errors, on a fresh install of wordpress 3.5, nothing special, just checking if the value for the key is set, I prevent it by check the key itself..

Hope this helps, and I'd love to see more activity around this amazing plugin.
